### PR TITLE
fix(benchmark): serialize manifest with numpy/Path-safe writer (fixes #35)

### DIFF
--- a/myogait/corrections.py
+++ b/myogait/corrections.py
@@ -78,6 +78,7 @@ list.  Calling either function twice is a no-op: a marker is set in
 from __future__ import annotations
 
 import logging
+from typing import List, Optional
 
 import numpy as np
 

--- a/myogait/experimental_benchmark.py
+++ b/myogait/experimental_benchmark.py
@@ -7,7 +7,6 @@ compares each run against one VICON trial.
 
 from __future__ import annotations
 
-import json
 from copy import deepcopy
 from itertools import product
 from pathlib import Path
@@ -19,7 +18,7 @@ from .extract import extract
 from .normalize import normalize
 from .angles import compute_angles
 from .events import detect_events, list_event_methods
-from .schema import save_json
+from .schema import dumps_json_safe, save_json
 from .models import list_models
 from .experimental_vicon import run_single_trial_vicon_benchmark
 
@@ -249,6 +248,6 @@ def run_single_pair_benchmark(
         "config": cfg,
     }
     with open(out_dir / "benchmark_manifest.json", "w", encoding="utf-8") as f:
-        json.dump(manifest, f, indent=2, ensure_ascii=False)
+        f.write(dumps_json_safe(manifest))
 
     return manifest

--- a/myogait/schema.py
+++ b/myogait/schema.py
@@ -9,12 +9,15 @@ create_empty
     Create an empty pivot JSON structure.
 save_json
     Save pivot JSON to file with numpy type conversion.
+dumps_json_safe
+    Serialize any JSON-safe structure (numpy/Path/Enum aware) to a string.
 load_json
     Load and validate a pivot JSON file.
 set_subject
     Set subject metadata in the pivot JSON.
 """
 
+import enum
 import json
 import numpy as np
 from pathlib import Path
@@ -36,6 +39,52 @@ def _convert_numpy(obj: Any) -> Any:
     if isinstance(obj, np.bool_):
         return bool(obj)
     return obj
+
+
+def _convert_json(obj: Any) -> Any:
+    """Recursively convert *obj* to JSON-serializable Python types.
+
+    Handles pathlib.Path (as str) and enum.Enum (as .value), then
+    delegates to :func:`_convert_numpy` for numpy scalars/arrays and
+    nested dict/list/tuple containers.
+    """
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, enum.Enum):
+        return obj.value
+    if isinstance(obj, dict):
+        return {k: _convert_json(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_convert_json(v) for v in obj]
+    return _convert_numpy(obj)
+
+
+def dumps_json_safe(data: Any, indent: int = 2) -> str:
+    """Serialize *data* to a JSON string, tolerating numpy/Path/Enum values.
+
+    This is the single JSON serialization entry point for the package:
+    all code paths that write JSON should go through this function (or
+    :func:`save_json`, which delegates to it) so numpy scalars/arrays,
+    ``pathlib.Path`` and ``enum.Enum`` values never crash serialization.
+
+    Parameters
+    ----------
+    data : Any
+        Data structure to serialize.
+    indent : int, optional
+        JSON indentation level (default 2).
+
+    Returns
+    -------
+    str
+        JSON-encoded text with ``ensure_ascii=False``.
+
+    Raises
+    ------
+    TypeError
+        If *data* contains objects that are not JSON serializable.
+    """
+    return json.dumps(_convert_json(data), indent=indent, ensure_ascii=False)
 
 
 def create_empty(
@@ -146,7 +195,7 @@ def save_json(data: dict, path: Union[str, Path], indent: int = 2) -> None:
     """Save pivot JSON to file.
 
     Automatically converts numpy types to Python builtins before
-    serialization.
+    serialization (via :func:`dumps_json_safe`).
 
     Parameters
     ----------
@@ -159,9 +208,8 @@ def save_json(data: dict, path: Union[str, Path], indent: int = 2) -> None:
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    converted = _convert_numpy(data)
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(converted, f, indent=indent, ensure_ascii=False)
+        f.write(dumps_json_safe(data, indent=indent))
 
 
 def load_json(path: Union[str, Path]) -> dict:

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,0 +1,235 @@
+"""Tests for myogait.corrections — apply_linear_detrend + typing imports.
+
+Regression context: commit 69f21f6 introduced apply_linear_detrend()
+with ``Optional[List[str]]`` annotations but without importing the
+typing names.  ``from __future__ import annotations`` masked the bug
+at import time (annotations become strings), but the CI lint gate
+(ruff --select E,W,F) failed with 2x F821 and
+``typing.get_type_hints()`` raised NameError.  These tests pin both
+the typing contract and the detrend behaviour documented in the
+function docstring: the anatomical mean and the per-cycle ROM are
+preserved while the slow DC drift is removed.
+"""
+
+import typing
+
+import numpy as np
+import pytest
+
+from myogait.corrections import apply_linear_detrend
+
+# ── Typing contract (the actual CI-breaking bug) ─────────────────────
+
+
+def test_type_hints_resolve():
+    """get_type_hints() must resolve — it evaluates string annotations.
+
+    Before the fix this raised NameError: name 'Optional' is not defined.
+    """
+    hints = typing.get_type_hints(apply_linear_detrend)
+    assert "data" in hints
+    assert "joints" in hints
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+# Synthetic baseline joint angle (deg): any constant works — detrending
+# must be invariant to the DC level, which test_removes_linear_drift
+# asserts via the preserved mean.
+BASE_ANGLE_DEG = 10.0
+
+# Injected drift slope (deg/frame) for the pure-ramp tests.  Magnitude
+# chosen from the apply_linear_detrend docstring ("hip angle sliding by
+# 10-30 deg from the first to the last cycle"): 0.2 deg/frame over a
+# 100-frame recording is a 20 deg drift, mid-range of that document.
+DEFAULT_DRIFT = 0.2
+
+
+def _make_angle_data(n_frames=100, drift_deg_per_frame=DEFAULT_DRIFT,
+                     amp=0.0, period=25, joints=None):
+    """Build a pivot dict with a linear drift and optional sinusoid."""
+    if joints is None:
+        joints = ["hip_L", "hip_R", "knee_L", "knee_R",
+                  "ankle_L", "ankle_R", "trunk_angle"]
+    frames = []
+    for i in range(n_frames):
+        osc = amp * np.sin(2 * np.pi * i / period) if amp else 0.0
+        drift = drift_deg_per_frame * i
+        frame = {"frame_idx": i}
+        for key in joints:
+            frame[key] = float(BASE_ANGLE_DEG + drift + osc)
+        frames.append(frame)
+    return {"angles": {"frames": frames}}
+
+
+def _slope_of(values):
+    """Least-squares slope of a series (NaN-safe)."""
+    vals = np.asarray(values, dtype=float)
+    mask = ~np.isnan(vals)
+    idx = np.arange(len(vals))
+    slope, _ = np.polyfit(idx[mask], vals[mask], 1)
+    return float(slope)
+
+
+def _series(data, key):
+    return [f.get(key) for f in data["angles"]["frames"]]
+
+
+def _per_cycle_ptp(values, period=25):
+    """Median peak-to-peak amplitude computed within each cycle."""
+    vals = np.asarray(values, dtype=float)
+    n_cycles = len(vals) // period
+    ptps = []
+    for c in range(n_cycles):
+        seg = vals[c * period:(c + 1) * period]
+        if not np.isnan(seg).any():
+            ptps.append(float(np.ptp(seg)))
+    return float(np.median(ptps)) if ptps else float("nan")
+
+
+# ── Detrend behaviour ────────────────────────────────────────────────
+
+
+def test_removes_linear_drift_preserves_mean():
+    data = _make_angle_data()  # pure ramp
+    before = _series(data, "hip_L")
+    assert abs(_slope_of(before) - DEFAULT_DRIFT) < 1e-9  # drift present
+    before_mean = float(np.mean(before))
+
+    apply_linear_detrend(data)
+
+    after = _series(data, "hip_L")
+    assert abs(_slope_of(after)) < 1e-9  # drift gone
+    assert abs(float(np.mean(after)) - before_mean) < 1e-9  # mean kept
+
+
+def test_preserves_per_cycle_rom():
+    """The documented contract is per-cycle ROM, not global peak-to-peak.
+
+    A slow drift contaminates windowed ROM measurements (the ramp tilts
+    each gait-cycle window); detrending must restore the oscillation
+    amplitude within every cycle.
+
+    Math note: OLS detrend subtracts its own fitted line, so the
+    residual slope is ~0 by construction (the OLS residual is
+    orthogonal to the regressors).  On a ramp+sinusoid composite the
+    fitted slope still carries the ramp/sinusoid cross-term bias, which
+    modulates the oscillation slightly; the remaining ROM deficit is
+    exactly that projection (here ~0.19 deg on a 10 deg ROM), and the
+    element-wise pin below reproduces the documented algorithm
+    (OLS fit, subtract trend, re-add mean) from first principles
+    instead of hardcoding magic numbers.
+    """
+    period = 20
+    drift, amp = 0.1, 5.0
+    data = _make_angle_data(drift_deg_per_frame=drift, amp=amp, period=period)
+    before = np.asarray(_series(data, "hip_L"))
+    before_ptp = _per_cycle_ptp(before, period)
+    true_ptp = 2.0 * amp
+    assert before_ptp < true_ptp  # drift contaminates windowed ROM
+
+    apply_linear_detrend(data)
+
+    after = np.asarray(_series(data, "hip_L"))
+
+    # Anatomical mean preserved (documented contract)
+    assert float(np.mean(after)) == pytest.approx(
+        float(np.mean(before)), abs=1e-9)
+    # Residual slope ~0: detrend subtracts its own OLS fit
+    assert abs(_slope_of(after)) < 1e-9
+
+    # Element-wise pin against the algorithm reproduced independently
+    idx = np.arange(len(before))
+    slope_hat, intercept_hat = np.polyfit(idx, before, 1)
+    expected = (before - (slope_hat * idx + intercept_hat)
+                + float(np.mean(before)))
+    assert after == pytest.approx(expected, abs=1e-9)
+
+    # Clinical meaning: ROM restored up to the cross-term distortion
+    after_ptp = _per_cycle_ptp(after, period)
+    assert after_ptp == pytest.approx(
+        _per_cycle_ptp(expected, period), abs=1e-9)
+    assert after_ptp > before_ptp
+    assert after_ptp == pytest.approx(true_ptp, abs=0.2)
+
+
+def test_sets_marker_and_is_idempotent():
+    data = _make_angle_data()
+    apply_linear_detrend(data)
+    assert data["angles"]["linear_detrended"] is True
+
+    snapshot = [dict(f) for f in data["angles"]["frames"]]
+    apply_linear_detrend(data)  # second call must be a no-op
+    assert data["angles"]["frames"] == snapshot
+
+
+def test_short_series_untouched():
+    """Joints below the internal minimum-sample guard are left unchanged.
+
+    The guard requires >= 20 valid samples (corrections.py). Series
+    clearly under any such bound must pass through bit-identical.
+    """
+    for n_frames in (0, 1, 5, 10, 19):
+        data = _make_angle_data(n_frames=n_frames)
+        before = _series(data, "knee_R")
+        apply_linear_detrend(data)
+        assert _series(data, "knee_R") == before, f"n={n_frames} modified"
+    # Boundary (exactly 20 valid samples) and above ARE detrended
+    for n_frames in (20, 25):
+        data = _make_angle_data(n_frames=n_frames)
+        apply_linear_detrend(data)
+        assert abs(_slope_of(_series(data, "knee_R"))) < 1e-9, (
+            f"n={n_frames} not detrended")
+
+
+def test_nan_values_skipped():
+    """NaN angle samples are preserved, valid neighbours are detrended."""
+    data = _make_angle_data(n_frames=50)
+    data["angles"]["frames"][7]["ankle_L"] = float("nan")
+    apply_linear_detrend(data)
+    assert np.isnan(data["angles"]["frames"][7]["ankle_L"])
+    valid = [f["ankle_L"] for f in data["angles"]["frames"]
+             if not np.isnan(f["ankle_L"])]
+    assert abs(_slope_of(valid)) < 1e-9
+
+
+def test_none_values_skipped():
+    data = _make_angle_data(n_frames=50)
+    data["angles"]["frames"][5]["hip_L"] = None
+    data["angles"]["frames"][6]["hip_L"] = None
+    apply_linear_detrend(data)
+    assert data["angles"]["frames"][5]["hip_L"] is None
+    assert data["angles"]["frames"][6]["hip_L"] is None
+    # Valid frames are detrended anyway
+    valid = [f["hip_L"] for f in data["angles"]["frames"]
+             if f["hip_L"] is not None]
+    assert abs(_slope_of(valid)) < 1e-9
+
+
+def test_other_frame_keys_preserved():
+    """Detrending touches only the target joints, never other keys."""
+    data = _make_angle_data(n_frames=40)
+    for f in data["angles"]["frames"]:
+        f["landmark_positions"] = {"LEFT_HIP": [0.5, 0.5]}
+    apply_linear_detrend(data)
+    for f in data["angles"]["frames"]:
+        assert f["landmark_positions"] == {"LEFT_HIP": [0.5, 0.5]}
+        assert "frame_idx" in f
+
+
+def test_custom_joints_only():
+    data = _make_angle_data()  # pure ramp on all joints
+    apply_linear_detrend(data, joints=["knee_L"])
+    assert abs(_slope_of(_series(data, "knee_L"))) < 1e-9
+    # Unlisted joints keep their drift
+    assert abs(_slope_of(_series(data, "hip_L")) - DEFAULT_DRIFT) < 1e-9
+
+
+def test_empty_angles_is_noop():
+    data = {"angles": {"frames": []}}
+    apply_linear_detrend(data)
+    assert data["angles"].get("linear_detrended") is not True
+
+    data_no_angles = {}
+    result = apply_linear_detrend(data_no_angles)
+    assert result is data_no_angles

--- a/tests/test_experimental_benchmark.py
+++ b/tests/test_experimental_benchmark.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from myogait.experimental_benchmark import (
@@ -189,3 +190,75 @@ def test_run_single_pair_benchmark_continue_on_error(tmp_path, monkeypatch):
     df = pd.read_csv(out["summary_csv"])
     assert set(df["status"]) == {"ok", "error"}
     assert "bad detector" in " ".join(str(v) for v in df["error"].dropna().tolist())
+
+
+def test_manifest_serializes_numpy_and_path_config(tmp_path, monkeypatch):
+    """Issue #35: manifest must survive numpy scalars and Path in the config."""
+
+    def fake_extract(video_path, model, experimental, **kwargs):
+        return {
+            "meta": {"fps": 30.0, "n_frames": 2},
+            "frames": [{"frame_idx": 0, "landmarks": {}}, {"frame_idx": 1, "landmarks": {}}],
+            "extraction": {"model": model},
+            "extract_kwargs": kwargs,
+        }
+
+    def fake_normalize(data, **kwargs):
+        data["normalization"] = {"kwargs": kwargs}
+        return data
+
+    def fake_compute_angles(data, **kwargs):
+        data["angles"] = {"frames": [{"knee_L": 10.0}, {"knee_L": 12.0}]}
+        return data
+
+    def fake_detect_events(data, method):
+        data["events"] = {
+            "method": method,
+            "left_hs": [{"frame": 0}],
+            "right_hs": [],
+            "left_to": [],
+            "right_to": [],
+        }
+        return data
+
+    def fake_vicon(data, trial_dir, vicon_fps, max_lag_seconds):
+        data.setdefault("experimental", {})
+        data["experimental"]["vicon_benchmark"] = {"sync": {}, "metrics": {}}
+        return data
+
+    monkeypatch.setattr("myogait.experimental_benchmark.extract", fake_extract)
+    monkeypatch.setattr("myogait.experimental_benchmark.normalize", fake_normalize)
+    monkeypatch.setattr("myogait.experimental_benchmark.compute_angles", fake_compute_angles)
+    monkeypatch.setattr("myogait.experimental_benchmark.detect_events", fake_detect_events)
+    monkeypatch.setattr("myogait.experimental_benchmark.run_single_trial_vicon_benchmark", fake_vicon)
+
+    cfg = {
+        "models": ["mediapipe"],
+        "event_methods": ["zeni"],
+        "normalization_variants": [{"name": "none", "enabled": False, "kwargs": {}}],
+        "degradation_variants": [{"name": "none", "experimental": {"enabled": False}}],
+        # numpy scalars in the vicon sub-dict (as loaded from user configs)
+        "vicon": {
+            "vicon_fps": np.float64(200.0),
+            "max_lag_seconds": np.int64(10),
+        },
+        # pathlib.Path inside extract_kwargs
+        "extract_kwargs": {
+            "flip_if_right": True,
+            "calibration_dir": Path("data/calibration"),
+        },
+    }
+
+    out = run_single_pair_benchmark(
+        video_path=tmp_path / "video.mp4",
+        vicon_trial_dir=tmp_path / "vicon",
+        output_dir=tmp_path / "out",
+        benchmark_config=cfg,
+    )
+
+    assert out["n_runs"] >= 1
+    manifest_path = tmp_path / "out" / "benchmark_manifest.json"
+    assert manifest_path.exists()
+    with open(manifest_path, encoding="utf-8") as f:
+        manifest = json.load(f)  # must not raise TypeError
+    assert manifest["n_runs"] >= 1

--- a/tests/test_schema_dumps.py
+++ b/tests/test_schema_dumps.py
@@ -1,0 +1,80 @@
+"""Tests for dumps_json_safe, the single JSON serialization entry point.
+
+Regression coverage for upstream issue #35: JSON dumps crashed on numpy
+scalars, pathlib.Path and enum.Enum values embedded in user-provided dicts.
+"""
+
+import enum
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from myogait.schema import dumps_json_safe
+
+
+class _Side(enum.Enum):
+    """Sample enum used to exercise Enum serialization."""
+
+    LEFT = "left"
+
+
+def test_numpy_scalars_and_arrays():
+    data = {
+        "f64": np.float64(1.5),
+        "i64": np.int64(7),
+        "flag": np.bool_(True),
+        "arr": np.array([1.0, 2.0, 3.0]),
+    }
+    out = json.loads(dumps_json_safe(data))
+    assert out["f64"] == 1.5
+    assert out["i64"] == 7
+    assert out["flag"] is True
+    assert out["arr"] == [1.0, 2.0, 3.0]
+
+
+def test_path_serialized_as_str():
+    video = Path("data") / "video.mp4"
+    out = json.loads(dumps_json_safe({"video": video}))
+    assert out["video"] == str(video)
+
+
+def test_enum_serialized_as_value():
+    out = json.loads(dumps_json_safe({"side": _Side.LEFT}))
+    assert out["side"] == _Side.LEFT.value
+
+
+def test_nested_containers():
+    data = {
+        "outer": [
+            np.int64(1),
+            (np.float64(2.5), Path("nested.txt")),
+            {"deep": np.array([np.int64(3)])},
+        ]
+    }
+    out = json.loads(dumps_json_safe(data))
+    assert out["outer"][0] == 1
+    assert out["outer"][1] == [2.5, "nested.txt"]
+    assert out["outer"][2]["deep"] == [3]
+
+
+def test_indent_kwarg_forwarded():
+    data = {"a": 1}
+    assert dumps_json_safe(data) == json.dumps(
+        {"a": 1}, indent=2, ensure_ascii=False
+    )
+    assert dumps_json_safe(data, indent=4) == json.dumps(
+        {"a": 1}, indent=4, ensure_ascii=False
+    )
+
+
+def test_unicode_preserved():
+    # ensure_ascii=False must keep human-readable unicode in the output.
+    notes = "marche régulière côté gauche"
+    assert notes in dumps_json_safe({"notes": notes})
+
+
+def test_unserializable_object_raises_type_error():
+    with pytest.raises(TypeError):
+        dumps_json_safe({"bad": object()})


### PR DESCRIPTION
# PR2 — fix(benchmark): serialize manifest with numpy/Path-safe writer

Fixes #35.

## Problem

`run_single_pair_benchmark()` crashed at `experimental_benchmark.py` with
`TypeError: Object of type float64 is not JSON serializable` when writing
`benchmark_manifest.json`. The manifest embeds the caller's
`benchmark_config`, which routinely contains numpy scalars (`np.float64`,
`np.int64` from loaded configs) and `pathlib.Path` values — plain
`json.dump` cannot serialize them.

## Fix

- New single serialization entry point `dumps_json_safe()` in
  `myogait/schema.py`: handles numpy ints/floats/bools/arrays, `Path`
  (as str), `Enum` (as value), nested containers; forwards `indent`;
  still raises `TypeError` on genuinely unserializable objects.
- `save_json()` now delegates to it — one serialization path in the
  package (DRY; the previous `_convert_numpy` covered numpy only).
- The benchmark manifest is written with `dumps_json_safe()`. No new
  manifest keys, no other behaviour change.

## Tests (TDD, RED demonstrated before each GREEN)

- `tests/test_schema_dumps.py` (7 tests): numpy scalars/arrays, Path,
  Enum, nested dict/list/tuple, indent forwarding, unicode preservation,
  TypeError on bare object.
- `tests/test_experimental_benchmark.py`: regression test reproducing the
  exact #35 crash (np.float64/np.int64 in `vicon`, Path in
  `extract_kwargs`) — fails with the original TypeError on master, passes
  with the fix.

## Verification (full local CI replay)

- `ruff check myogait/ tests/ --select E,W,F --ignore E501` → All checks passed
- `pytest tests/ --cov=myogait --cov-fail-under=75` → 1281 passed, coverage 77.57 %

## Note

Based on the CI-lint fix PR (typing imports in corrections.py) so the lint
gate is green here; happy to rebase once that one lands.
