### PR TITLE
feat(vicon-sync): robust synchronization + actionable diagnostics (fixes #34)

### DIFF
--- a/myogait/corrections.py
+++ b/myogait/corrections.py
@@ -78,6 +78,7 @@ list.  Calling either function twice is a no-op: a marker is set in
 from __future__ import annotations
 
 import logging
+from typing import List, Optional
 
 import numpy as np
 

--- a/myogait/experimental_benchmark.py
+++ b/myogait/experimental_benchmark.py
@@ -21,7 +21,7 @@ from .angles import compute_angles
 from .events import detect_events, list_event_methods
 from .schema import save_json
 from .models import list_models
-from .experimental_vicon import run_single_trial_vicon_benchmark
+from .experimental_vicon import SyncError, run_single_trial_vicon_benchmark
 
 
 DEFAULT_SINGLE_PAIR_BENCHMARK_CONFIG: Dict[str, Any] = {
@@ -221,8 +221,18 @@ def run_single_pair_benchmark(
             save_json(data, run_json)
             row = _flatten_row_metrics(row, data)
 
+        except SyncError as exc:
+            row["status"] = "error"
+            row["error_kind"] = "SyncError"
+            row["error"] = str(exc)
+            if not continue_on_error:
+                rows.append(row)
+                summary_path = out_dir / "benchmark_summary.csv"
+                pd.DataFrame(rows).to_csv(summary_path, index=False)
+                raise
         except Exception as exc:  # noqa: BLE001
             row["status"] = "error"
+            row["error_kind"] = type(exc).__name__
             row["error"] = str(exc)
             if not continue_on_error:
                 rows.append(row)

--- a/myogait/experimental_vicon.py
+++ b/myogait/experimental_vicon.py
@@ -28,6 +28,17 @@ _ANGLE_CANDIDATES = {
     "ankle_R": ("Rankle", "r_ankle"),
 }
 
+# Joints considered for video<->VICON temporal synchronization, in priority
+# order.  Knees first: they have the largest sagittal range of motion during
+# gait, which gives the strongest cross-correlation signal.  Hips are kept as
+# a fallback for recordings where knee tracking is partial or missing (common
+# in slow pathological gait, e.g. DMD/SMA).
+_SYNC_CANDIDATE_JOINTS = ("knee_L", "knee_R", "hip_L", "hip_R")
+
+# Minimum number of samples on the best candidate signal for a meaningful
+# cross-correlation lag estimate (10 samples at 30 fps ~= 0.33 s of motion).
+_MIN_SYNC_SAMPLES = 10
+
 _LANDMARK_TO_VICON_MARKERS = {
     "LEFT_HIP": ("LHJC",),
     "RIGHT_HIP": ("RHJC",),
@@ -189,11 +200,10 @@ def _myogait_angle_arrays(data: dict) -> Dict[str, np.ndarray]:
 
 
 def _best_sync_signal(mg_angles: Dict[str, np.ndarray], vc_angles: Dict[str, np.ndarray]) -> Tuple[str, np.ndarray, np.ndarray]:
-    candidates = ("knee_L", "knee_R")
     best_name = None
     best_len = -1
     best_pair = (np.array([]), np.array([]))
-    for name in candidates:
+    for name in _SYNC_CANDIDATE_JOINTS:
         a = _interp_nan(mg_angles.get(name, np.array([])))
         b = _interp_nan(vc_angles.get(name, np.array([])))
         valid = min(len(a), len(b))
@@ -223,7 +233,7 @@ def estimate_vicon_offset_seconds(
     mg_angles = _myogait_angle_arrays(myogait_data)
     vc_angles = vicon_data.get("angles", {})
     signal_name, mg_sig, vc_sig = _best_sync_signal(mg_angles, vc_angles)
-    if len(mg_sig) < 10 or len(vc_sig) < 10:
+    if len(mg_sig) < _MIN_SYNC_SAMPLES or len(vc_sig) < _MIN_SYNC_SAMPLES:
         raise ValueError("Not enough angle samples for synchronization")
 
     # Resample both to common frequency for stable lag estimate.

--- a/myogait/experimental_vicon.py
+++ b/myogait/experimental_vicon.py
@@ -39,6 +39,21 @@ _SYNC_CANDIDATE_JOINTS = ("knee_L", "knee_R", "hip_L", "hip_R")
 # cross-correlation lag estimate (10 samples at 30 fps ~= 0.33 s of motion).
 _MIN_SYNC_SAMPLES = 10
 
+
+class SyncError(ValueError):
+    """Video<->VICON temporal synchronization failed.
+
+    Carries a structured diagnostic (per-candidate sample counts) so
+    callers such as the benchmark orchestrator can report WHY the sync
+    failed instead of a bare message.  Inherits ValueError for
+    backward compatibility with existing ``except ValueError`` handlers.
+    """
+
+    def __init__(self, message: str, candidates: dict, required: int):
+        super().__init__(message)
+        self.candidates = dict(candidates)
+        self.required = int(required)
+
 _LANDMARK_TO_VICON_MARKERS = {
     "LEFT_HIP": ("LHJC",),
     "RIGHT_HIP": ("RHJC",),
@@ -234,7 +249,20 @@ def estimate_vicon_offset_seconds(
     vc_angles = vicon_data.get("angles", {})
     signal_name, mg_sig, vc_sig = _best_sync_signal(mg_angles, vc_angles)
     if len(mg_sig) < _MIN_SYNC_SAMPLES or len(vc_sig) < _MIN_SYNC_SAMPLES:
-        raise ValueError("Not enough angle samples for synchronization")
+        counts = {}
+        for name in _SYNC_CANDIDATE_JOINTS:
+            a = _interp_nan(mg_angles.get(name, np.array([])))
+            b = _interp_nan(vc_angles.get(name, np.array([])))
+            counts[name] = int(min(len(a), len(b)))
+        detail = ", ".join(f"{name}={counts[name]}" for name in _SYNC_CANDIDATE_JOINTS)
+        raise SyncError(
+            "Not enough angle samples for synchronization "
+            f"({detail}; need >= {_MIN_SYNC_SAMPLES} on the best candidate). "
+            "Try a longer recording or check that compute_angles() ran on "
+            "the video side.",
+            candidates=counts,
+            required=_MIN_SYNC_SAMPLES,
+        )
 
     # Resample both to common frequency for stable lag estimate.
     common_fps = min(fps_mg, fps_vc)

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,0 +1,235 @@
+"""Tests for myogait.corrections — apply_linear_detrend + typing imports.
+
+Regression context: commit 69f21f6 introduced apply_linear_detrend()
+with ``Optional[List[str]]`` annotations but without importing the
+typing names.  ``from __future__ import annotations`` masked the bug
+at import time (annotations become strings), but the CI lint gate
+(ruff --select E,W,F) failed with 2x F821 and
+``typing.get_type_hints()`` raised NameError.  These tests pin both
+the typing contract and the detrend behaviour documented in the
+function docstring: the anatomical mean and the per-cycle ROM are
+preserved while the slow DC drift is removed.
+"""
+
+import typing
+
+import numpy as np
+import pytest
+
+from myogait.corrections import apply_linear_detrend
+
+# ── Typing contract (the actual CI-breaking bug) ─────────────────────
+
+
+def test_type_hints_resolve():
+    """get_type_hints() must resolve — it evaluates string annotations.
+
+    Before the fix this raised NameError: name 'Optional' is not defined.
+    """
+    hints = typing.get_type_hints(apply_linear_detrend)
+    assert "data" in hints
+    assert "joints" in hints
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+# Synthetic baseline joint angle (deg): any constant works — detrending
+# must be invariant to the DC level, which test_removes_linear_drift
+# asserts via the preserved mean.
+BASE_ANGLE_DEG = 10.0
+
+# Injected drift slope (deg/frame) for the pure-ramp tests.  Magnitude
+# chosen from the apply_linear_detrend docstring ("hip angle sliding by
+# 10-30 deg from the first to the last cycle"): 0.2 deg/frame over a
+# 100-frame recording is a 20 deg drift, mid-range of that document.
+DEFAULT_DRIFT = 0.2
+
+
+def _make_angle_data(n_frames=100, drift_deg_per_frame=DEFAULT_DRIFT,
+                     amp=0.0, period=25, joints=None):
+    """Build a pivot dict with a linear drift and optional sinusoid."""
+    if joints is None:
+        joints = ["hip_L", "hip_R", "knee_L", "knee_R",
+                  "ankle_L", "ankle_R", "trunk_angle"]
+    frames = []
+    for i in range(n_frames):
+        osc = amp * np.sin(2 * np.pi * i / period) if amp else 0.0
+        drift = drift_deg_per_frame * i
+        frame = {"frame_idx": i}
+        for key in joints:
+            frame[key] = float(BASE_ANGLE_DEG + drift + osc)
+        frames.append(frame)
+    return {"angles": {"frames": frames}}
+
+
+def _slope_of(values):
+    """Least-squares slope of a series (NaN-safe)."""
+    vals = np.asarray(values, dtype=float)
+    mask = ~np.isnan(vals)
+    idx = np.arange(len(vals))
+    slope, _ = np.polyfit(idx[mask], vals[mask], 1)
+    return float(slope)
+
+
+def _series(data, key):
+    return [f.get(key) for f in data["angles"]["frames"]]
+
+
+def _per_cycle_ptp(values, period=25):
+    """Median peak-to-peak amplitude computed within each cycle."""
+    vals = np.asarray(values, dtype=float)
+    n_cycles = len(vals) // period
+    ptps = []
+    for c in range(n_cycles):
+        seg = vals[c * period:(c + 1) * period]
+        if not np.isnan(seg).any():
+            ptps.append(float(np.ptp(seg)))
+    return float(np.median(ptps)) if ptps else float("nan")
+
+
+# ── Detrend behaviour ────────────────────────────────────────────────
+
+
+def test_removes_linear_drift_preserves_mean():
+    data = _make_angle_data()  # pure ramp
+    before = _series(data, "hip_L")
+    assert abs(_slope_of(before) - DEFAULT_DRIFT) < 1e-9  # drift present
+    before_mean = float(np.mean(before))
+
+    apply_linear_detrend(data)
+
+    after = _series(data, "hip_L")
+    assert abs(_slope_of(after)) < 1e-9  # drift gone
+    assert abs(float(np.mean(after)) - before_mean) < 1e-9  # mean kept
+
+
+def test_preserves_per_cycle_rom():
+    """The documented contract is per-cycle ROM, not global peak-to-peak.
+
+    A slow drift contaminates windowed ROM measurements (the ramp tilts
+    each gait-cycle window); detrending must restore the oscillation
+    amplitude within every cycle.
+
+    Math note: OLS detrend subtracts its own fitted line, so the
+    residual slope is ~0 by construction (the OLS residual is
+    orthogonal to the regressors).  On a ramp+sinusoid composite the
+    fitted slope still carries the ramp/sinusoid cross-term bias, which
+    modulates the oscillation slightly; the remaining ROM deficit is
+    exactly that projection (here ~0.19 deg on a 10 deg ROM), and the
+    element-wise pin below reproduces the documented algorithm
+    (OLS fit, subtract trend, re-add mean) from first principles
+    instead of hardcoding magic numbers.
+    """
+    period = 20
+    drift, amp = 0.1, 5.0
+    data = _make_angle_data(drift_deg_per_frame=drift, amp=amp, period=period)
+    before = np.asarray(_series(data, "hip_L"))
+    before_ptp = _per_cycle_ptp(before, period)
+    true_ptp = 2.0 * amp
+    assert before_ptp < true_ptp  # drift contaminates windowed ROM
+
+    apply_linear_detrend(data)
+
+    after = np.asarray(_series(data, "hip_L"))
+
+    # Anatomical mean preserved (documented contract)
+    assert float(np.mean(after)) == pytest.approx(
+        float(np.mean(before)), abs=1e-9)
+    # Residual slope ~0: detrend subtracts its own OLS fit
+    assert abs(_slope_of(after)) < 1e-9
+
+    # Element-wise pin against the algorithm reproduced independently
+    idx = np.arange(len(before))
+    slope_hat, intercept_hat = np.polyfit(idx, before, 1)
+    expected = (before - (slope_hat * idx + intercept_hat)
+                + float(np.mean(before)))
+    assert after == pytest.approx(expected, abs=1e-9)
+
+    # Clinical meaning: ROM restored up to the cross-term distortion
+    after_ptp = _per_cycle_ptp(after, period)
+    assert after_ptp == pytest.approx(
+        _per_cycle_ptp(expected, period), abs=1e-9)
+    assert after_ptp > before_ptp
+    assert after_ptp == pytest.approx(true_ptp, abs=0.2)
+
+
+def test_sets_marker_and_is_idempotent():
+    data = _make_angle_data()
+    apply_linear_detrend(data)
+    assert data["angles"]["linear_detrended"] is True
+
+    snapshot = [dict(f) for f in data["angles"]["frames"]]
+    apply_linear_detrend(data)  # second call must be a no-op
+    assert data["angles"]["frames"] == snapshot
+
+
+def test_short_series_untouched():
+    """Joints below the internal minimum-sample guard are left unchanged.
+
+    The guard requires >= 20 valid samples (corrections.py). Series
+    clearly under any such bound must pass through bit-identical.
+    """
+    for n_frames in (0, 1, 5, 10, 19):
+        data = _make_angle_data(n_frames=n_frames)
+        before = _series(data, "knee_R")
+        apply_linear_detrend(data)
+        assert _series(data, "knee_R") == before, f"n={n_frames} modified"
+    # Boundary (exactly 20 valid samples) and above ARE detrended
+    for n_frames in (20, 25):
+        data = _make_angle_data(n_frames=n_frames)
+        apply_linear_detrend(data)
+        assert abs(_slope_of(_series(data, "knee_R"))) < 1e-9, (
+            f"n={n_frames} not detrended")
+
+
+def test_nan_values_skipped():
+    """NaN angle samples are preserved, valid neighbours are detrended."""
+    data = _make_angle_data(n_frames=50)
+    data["angles"]["frames"][7]["ankle_L"] = float("nan")
+    apply_linear_detrend(data)
+    assert np.isnan(data["angles"]["frames"][7]["ankle_L"])
+    valid = [f["ankle_L"] for f in data["angles"]["frames"]
+             if not np.isnan(f["ankle_L"])]
+    assert abs(_slope_of(valid)) < 1e-9
+
+
+def test_none_values_skipped():
+    data = _make_angle_data(n_frames=50)
+    data["angles"]["frames"][5]["hip_L"] = None
+    data["angles"]["frames"][6]["hip_L"] = None
+    apply_linear_detrend(data)
+    assert data["angles"]["frames"][5]["hip_L"] is None
+    assert data["angles"]["frames"][6]["hip_L"] is None
+    # Valid frames are detrended anyway
+    valid = [f["hip_L"] for f in data["angles"]["frames"]
+             if f["hip_L"] is not None]
+    assert abs(_slope_of(valid)) < 1e-9
+
+
+def test_other_frame_keys_preserved():
+    """Detrending touches only the target joints, never other keys."""
+    data = _make_angle_data(n_frames=40)
+    for f in data["angles"]["frames"]:
+        f["landmark_positions"] = {"LEFT_HIP": [0.5, 0.5]}
+    apply_linear_detrend(data)
+    for f in data["angles"]["frames"]:
+        assert f["landmark_positions"] == {"LEFT_HIP": [0.5, 0.5]}
+        assert "frame_idx" in f
+
+
+def test_custom_joints_only():
+    data = _make_angle_data()  # pure ramp on all joints
+    apply_linear_detrend(data, joints=["knee_L"])
+    assert abs(_slope_of(_series(data, "knee_L"))) < 1e-9
+    # Unlisted joints keep their drift
+    assert abs(_slope_of(_series(data, "hip_L")) - DEFAULT_DRIFT) < 1e-9
+
+
+def test_empty_angles_is_noop():
+    data = {"angles": {"frames": []}}
+    apply_linear_detrend(data)
+    assert data["angles"].get("linear_detrended") is not True
+
+    data_no_angles = {}
+    result = apply_linear_detrend(data_no_angles)
+    assert result is data_no_angles

--- a/tests/test_experimental_benchmark.py
+++ b/tests/test_experimental_benchmark.py
@@ -189,3 +189,60 @@ def test_run_single_pair_benchmark_continue_on_error(tmp_path, monkeypatch):
     df = pd.read_csv(out["summary_csv"])
     assert set(df["status"]) == {"ok", "error"}
     assert "bad detector" in " ".join(str(v) for v in df["error"].dropna().tolist())
+
+
+def test_run_single_pair_benchmark_surfaces_sync_error_diagnostic(tmp_path, monkeypatch):
+    from myogait.experimental_vicon import SyncError
+
+    def fake_extract(video_path, model, experimental, **kwargs):
+        return {
+            "meta": {"fps": 30.0, "n_frames": 3},
+            "frames": [{"frame_idx": i, "landmarks": {}} for i in range(3)],
+            "extraction": {"model": model},
+        }
+
+    def fake_compute_angles(data, **kwargs):
+        data["angles"] = {"frames": [{"knee_L": 10.0} for _ in range(3)]}
+        return data
+
+    def fake_detect_events(data, method):
+        data["events"] = {"left_hs": [{"frame": 1}], "right_hs": [], "left_to": [], "right_to": []}
+        return data
+
+    def fake_vicon(data, trial_dir, vicon_fps, max_lag_seconds):
+        raise SyncError(
+            "Not enough angle samples for synchronization "
+            "(knee_L=3, knee_R=0, hip_L=0, hip_R=0; need >= 10 on the best "
+            "candidate). Try a longer recording or check that compute_angles() "
+            "ran on the video side.",
+            candidates={"knee_L": 3, "knee_R": 0, "hip_L": 0, "hip_R": 0},
+            required=10,
+        )
+
+    monkeypatch.setattr("myogait.experimental_benchmark.extract", fake_extract)
+    monkeypatch.setattr("myogait.experimental_benchmark.compute_angles", fake_compute_angles)
+    monkeypatch.setattr("myogait.experimental_benchmark.detect_events", fake_detect_events)
+    monkeypatch.setattr("myogait.experimental_benchmark.run_single_trial_vicon_benchmark", fake_vicon)
+
+    cfg = {
+        "models": ["mediapipe"],
+        "event_methods": ["zeni"],
+        "normalization_variants": [{"name": "none", "enabled": False, "kwargs": {}}],
+        "degradation_variants": [{"name": "none", "experimental": {"enabled": False}}],
+        "continue_on_error": True,
+    }
+    out = run_single_pair_benchmark(
+        video_path=tmp_path / "video.mp4",
+        vicon_trial_dir=tmp_path / "vicon",
+        output_dir=tmp_path / "bench_sync_err",
+        benchmark_config=cfg,
+    )
+    assert out["n_runs"] == 1
+    assert out["n_ok"] == 0
+    assert out["n_error"] == 1
+
+    df = pd.read_csv(out["summary_csv"])
+    assert len(df) == 1
+    assert df.iloc[0]["status"] == "error"
+    assert "knee_L=3" in str(df.iloc[0]["error"])
+    assert df.iloc[0]["error_kind"] == "SyncError"

--- a/tests/test_experimental_vicon.py
+++ b/tests/test_experimental_vicon.py
@@ -119,3 +119,23 @@ def test_best_sync_falls_back_to_hip_when_knees_missing():
     name, a, b = _best_sync_signal(mg, vc)
     assert name == "hip_L"
     assert len(a) == 50
+
+
+def test_insufficient_samples_raises_syncerror_with_diagnostic():
+    from myogait.experimental_vicon import SyncError, estimate_vicon_offset_seconds
+    mg = {"meta": {"fps": 30.0}, "angles": {"frames": [
+        {"knee_L": 1.0, "knee_R": 1.0, "hip_L": 0.0, "hip_R": 0.0}
+        for _ in range(3)]}}
+    vc = {"meta": {"fps": 200.0, "n_frames": 400}, "angles": {
+        "knee_L": np.zeros(400), "knee_R": np.zeros(400),
+        "hip_L": np.zeros(400), "hip_R": np.zeros(400)}}
+    with pytest.raises(SyncError) as exc_info:
+        estimate_vicon_offset_seconds(mg, vc)
+    err = exc_info.value
+    assert err.required == 10
+    assert err.candidates["knee_L"] == 3
+    assert err.candidates["hip_L"] == 3
+    msg = str(err)
+    assert "Not enough angle samples" in msg
+    assert "knee_L=3" in msg
+    assert "longer recording" in msg

--- a/tests/test_experimental_vicon.py
+++ b/tests/test_experimental_vicon.py
@@ -103,3 +103,19 @@ def test_attach_experimental_block():
     assert "experimental" in out
     assert "vicon_benchmark" in out["experimental"]
     assert out["experimental"]["vicon_benchmark"]["status"] == "experimental"
+
+
+def test_sync_candidates_constant_includes_hips():
+    from myogait.experimental_vicon import _SYNC_CANDIDATE_JOINTS, _MIN_SYNC_SAMPLES
+    assert _SYNC_CANDIDATE_JOINTS[:2] == ("knee_L", "knee_R")  # knees first (best signal)
+    assert "hip_L" in _SYNC_CANDIDATE_JOINTS and "hip_R" in _SYNC_CANDIDATE_JOINTS
+    assert isinstance(_MIN_SYNC_SAMPLES, int) and _MIN_SYNC_SAMPLES >= 10
+
+
+def test_best_sync_falls_back_to_hip_when_knees_missing():
+    from myogait.experimental_vicon import _best_sync_signal
+    mg = {"hip_L": np.zeros(50)}
+    vc = {"hip_L": np.zeros(50), "knee_L": np.zeros(60)}
+    name, a, b = _best_sync_signal(mg, vc)
+    assert name == "hip_L"
+    assert len(a) == 50


### PR DESCRIPTION
# PR3 — feat(vicon-sync): robust synchronization + actionable diagnostics

Fixes #34.

## Problem

`estimate_vicon_offset_seconds()` raised a bare
`ValueError("Not enough angle samples for synchronization")` with no
diagnostic, and only considered knee angles. On short recordings or
partial knee tracking (common in slow pathological gait, e.g. DMD/SMA),
users — including the AIM pilot runs behind #34 — got an opaque failure.

## Changes

1. **Wider sync candidates**: `_SYNC_CANDIDATE_JOINTS =
   ("knee_L", "knee_R", "hip_L", "hip_R")` — knees first (largest sagittal
   ROM = best cross-correlation signal), hips as fallback when knee
   tracking is partial. Longest-common-valid-window selection unchanged.
2. **Named threshold**: `_MIN_SYNC_SAMPLES = 10` with provenance comment
   (replaces the magic literal).
3. **`SyncError(ValueError)`** carrying a structured diagnostic:
   per-candidate sample counts (`.candidates`) and `.required`; the
   message keeps the historical "Not enough angle samples" phrase and adds
   per-joint counts plus actionable guidance ("longer recording / check
   compute_angles()"). Inheriting `ValueError` keeps every existing
   `except ValueError` handler working (existing test unchanged and green).
4. **Benchmark surfaces the diagnostic**: per-run rows gain an
   `error_kind` column; `SyncError` rows carry the full per-joint counts
   in `error`, so a failed pair is diagnosable from
   `benchmark_summary.csv` instead of a bare message.

## Tests (TDD, RED demonstrated before each GREEN)

- Constants include hips with knees first; threshold named.
- `_best_sync_signal` falls back to hip when knees are absent; the
  existing synthetic test still selects a knee (no behaviour change on
  good data).
- `SyncError` raised with `candidates`/`required` and message content.
- Benchmark row carries `error_kind="SyncError"` + diagnostic.

## Honest scope note

The diagnostic/UX part is strictly better and fully tested. The hip
fallback is unit-tested on synthetic signals; confirmation on the real
AIM pilot pairs (the data behind #34) is pending — feedback from the
pilot owners very welcome. Backward compatibility is preserved
(SyncError is a ValueError; knees still preferred).

## Verification (full local CI replay)

- `ruff check myogait/ tests/ --select E,W,F --ignore E501` → All checks passed
- `pytest tests/ --cov=myogait --cov-fail-under=75` → 1277 passed, coverage 77.58 %

## Note

Based on the CI-lint fix PR so the gate is green; happy to rebase once it lands.
