### PR TITLE
feat(cli): opt-in sagittal drift correction (--detrend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,27 @@ print(f"Mean coherence: {data['coherence_summary']['mean']:.3f}")
 print(f"Low frames: {data['coherence_summary']['low_coherence_frames']}")
 ```
 
+### Sagittal drift correction (opt-in)
+
+Long recordings with a fixed camera show a slow angular drift (projection
+artifact as the subject's distance to the camera changes): hip angles can
+slide by 10–30° from the first to the last cycle. `apply_linear_detrend()`
+(myogait.corrections) fits and removes that linear drift per joint while
+preserving the anatomical mean and per-cycle ROM.
+
+```python
+from myogait.corrections import apply_linear_detrend
+data = apply_linear_detrend(data)   # after compute_angles()
+```
+
+or via the CLI: `myogait analyze video.json --detrend`.
+
+**Caveat:** the correction family in this module was calibrated on healthy
+adults; on pathological gait a real kinematic drift can be part of the
+clinical picture. Keep the flag off by default and compare with/without
+before drawing clinical conclusions (see the warnings at the top of
+`myogait/corrections.py`).
+
 ### Normative Comparison
 
 Compare patient kinematics against published normative reference bands

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1074,6 +1074,10 @@ myogait extract walk.mp4 -m sapiens2-top --with-depth --with-seg
 myogait analyze result.json --csv --pdf --language fr
 ```
 
+If long recordings show a slow angular drift (hip angles sliding over the
+video), add the opt-in `--detrend` flag to remove it before analysis — see
+the "Sagittal drift correction" section of the README for the caveats.
+
 ### Batch Processing
 
 ```bash

--- a/myogait/cli.py
+++ b/myogait/cli.py
@@ -143,6 +143,17 @@ def cmd_analyze(args):
         print("Error: JSON has no angles. Run the full pipeline first.")
         sys.exit(1)
 
+    # Opt-in sagittal drift correction (must stay off by default: the
+    # correction family is validated on healthy adults only — see the
+    # warnings at the top of myogait/corrections.py).
+    if getattr(args, "detrend", False):
+        from .corrections import apply_linear_detrend
+
+        data = apply_linear_detrend(data)
+        save_json(data, args.json_file)
+        print("Detrend: removed linear drift from joint angles "
+              "(see corrections module caveats).")
+
     # Detect events if not present
     if not data.get("events"):
         print("Detecting gait events (Zeni)...")
@@ -565,6 +576,13 @@ def main():
     p_analyze.add_argument("--mot", action="store_true", help="Export OpenSim .mot file")
     p_analyze.add_argument("--trc", action="store_true", help="Export OpenSim .trc file")
     p_analyze.add_argument("--excel", action="store_true", help="Export Excel workbook")
+    p_analyze.add_argument(
+        "--detrend",
+        action="store_true",
+        help="Remove slow sagittal drift from joint angles before analysis "
+             "(opt-in; validated on healthy-adult data only — see "
+             "myogait.corrections caveats)",
+    )
     p_analyze.set_defaults(func=cmd_analyze)
 
     # batch

--- a/myogait/corrections.py
+++ b/myogait/corrections.py
@@ -78,6 +78,7 @@ list.  Calling either function twice is a no-op: a marker is set in
 from __future__ import annotations
 
 import logging
+from typing import List, Optional
 
 import numpy as np
 

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -160,3 +160,144 @@ def test_cmd_batch_no_match_exits():
     args = argparse.Namespace(inputs=["/no/match/*.mp4"], output_dir="out", config=None, model="mediapipe", csv=False, pdf=False)
     with pytest.raises(SystemExit):
         cli.cmd_batch(args)
+
+
+# ── analyze --detrend (opt-in sagittal drift correction) ─────────────
+
+# Injected drift (deg/frame) for the CLI detrend tests: 0.2 deg/frame
+# over 40 frames is an 8 deg slide, within the 10-30 deg range quoted
+# in the apply_linear_detrend docstring for real recordings.
+_DETREND_DRIFT = 0.2
+_DETREND_BASE = 10.0
+_DETREND_N_FRAMES = 40  # >= 20 valid samples required by the OLS fit
+
+
+def _write_detrend_fixture(tmp_path):
+    """Write a pivot JSON with a linear ramp on hip_L and events present.
+
+    Events are pre-populated (shape copied from the benchmark fakes) so
+    cmd_analyze takes the "events already present" branch and does not
+    re-run detection.
+    """
+    from myogait.schema import create_empty, save_json
+
+    data = create_empty(video_path="x.mp4", fps=30.0, n_frames=_DETREND_N_FRAMES)
+    frames = []
+    for i in range(_DETREND_N_FRAMES):
+        frames.append({
+            "frame_idx": i,
+            "hip_L": float(_DETREND_BASE + _DETREND_DRIFT * i),
+        })
+    data["angles"] = {"frames": frames}
+    data["events"] = {
+        "method": "test",
+        "left_hs": [{"frame": 1}],
+        "right_hs": [{"frame": 2}],
+        "left_to": [{"frame": 1}],
+        "right_to": [{"frame": 2}],
+    }
+    path = tmp_path / "detrend.json"
+    save_json(data, str(path))
+    return str(path)
+
+
+def _analyze_args(json_file, detrend):
+    return argparse.Namespace(
+        json_file=json_file,
+        output_dir=".",
+        no_plots=True,
+        pdf=False,
+        csv=False,
+        mot=False,
+        trc=False,
+        excel=False,
+        detrend=detrend,
+    )
+
+
+def _stub_analyze_pipeline(monkeypatch):
+    """Stub the heavy steps cmd_analyze runs after detrending."""
+    monkeypatch.setattr("myogait.segment_cycles", lambda data: {"cycles": []})
+    monkeypatch.setattr(
+        "myogait.analyze_gait", lambda data, cycles: {"spatiotemporal": {}}
+    )
+
+
+def test_analyze_detrend_flag_registered(monkeypatch):
+    """The analyze subparser exposes --detrend, defaulting to False.
+
+    Detrending must stay opt-in (validations exist only for healthy
+    adults), so the flag must be absent-by-default and store_true.
+    """
+    from myogait import cli
+
+    captured = {}
+
+    def _fake(args):
+        captured["args"] = args
+
+    monkeypatch.setattr(cli, "cmd_analyze", _fake)
+
+    monkeypatch.setattr(
+        "sys.argv", ["myogait", "analyze", "x.json", "--detrend", "--no-plots"]
+    )
+    cli.main()
+    assert captured["args"].detrend is True
+
+    monkeypatch.setattr("sys.argv", ["myogait", "analyze", "x.json", "--no-plots"])
+    cli.main()
+    assert captured["args"].detrend is False
+
+
+def test_cmd_analyze_detrend_applies_and_persists(monkeypatch, tmp_path, capsys):
+    """--detrend removes the drift AND saves the corrected JSON back."""
+    import numpy as np
+
+    from myogait import cli
+    from myogait.schema import load_json
+
+    path = _write_detrend_fixture(tmp_path)
+    before = load_json(path)
+    before_vals = np.array(
+        [f["hip_L"] for f in before["angles"]["frames"]], dtype=float
+    )
+    before_mean = float(np.mean(before_vals))
+    idx = np.arange(len(before_vals))
+    before_slope = float(np.polyfit(idx, before_vals, 1)[0])
+    assert abs(before_slope - _DETREND_DRIFT) < 1e-9  # drift present
+
+    _stub_analyze_pipeline(monkeypatch)
+    cli.cmd_analyze(_analyze_args(path, detrend=True))
+
+    out = capsys.readouterr().out
+    assert "Detrend" in out
+
+    # Persisted to disk, not just in memory.
+    saved = load_json(path)
+    assert saved["angles"].get("linear_detrended") is True
+    saved_vals = np.array(
+        [f["hip_L"] for f in saved["angles"]["frames"]], dtype=float
+    )
+    assert abs(float(np.polyfit(idx, saved_vals, 1)[0])) < 1e-9  # drift gone
+    assert abs(float(np.mean(saved_vals)) - before_mean) < 1e-9  # mean kept
+
+
+def test_cmd_analyze_without_detrend_flag_leaves_angles_untouched(
+    monkeypatch, tmp_path
+):
+    """Without --detrend the angles on disk keep their drift."""
+    import numpy as np
+
+    from myogait import cli
+    from myogait.schema import load_json
+
+    path = _write_detrend_fixture(tmp_path)
+
+    _stub_analyze_pipeline(monkeypatch)
+    cli.cmd_analyze(_analyze_args(path, detrend=False))
+
+    saved = load_json(path)
+    assert "linear_detrended" not in saved["angles"]
+    vals = np.array([f["hip_L"] for f in saved["angles"]["frames"]], dtype=float)
+    idx = np.arange(len(vals))
+    assert abs(float(np.polyfit(idx, vals, 1)[0]) - _DETREND_DRIFT) < 1e-9

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,0 +1,235 @@
+"""Tests for myogait.corrections — apply_linear_detrend + typing imports.
+
+Regression context: commit 69f21f6 introduced apply_linear_detrend()
+with ``Optional[List[str]]`` annotations but without importing the
+typing names.  ``from __future__ import annotations`` masked the bug
+at import time (annotations become strings), but the CI lint gate
+(ruff --select E,W,F) failed with 2x F821 and
+``typing.get_type_hints()`` raised NameError.  These tests pin both
+the typing contract and the detrend behaviour documented in the
+function docstring: the anatomical mean and the per-cycle ROM are
+preserved while the slow DC drift is removed.
+"""
+
+import typing
+
+import numpy as np
+import pytest
+
+from myogait.corrections import apply_linear_detrend
+
+# ── Typing contract (the actual CI-breaking bug) ─────────────────────
+
+
+def test_type_hints_resolve():
+    """get_type_hints() must resolve — it evaluates string annotations.
+
+    Before the fix this raised NameError: name 'Optional' is not defined.
+    """
+    hints = typing.get_type_hints(apply_linear_detrend)
+    assert "data" in hints
+    assert "joints" in hints
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+# Synthetic baseline joint angle (deg): any constant works — detrending
+# must be invariant to the DC level, which test_removes_linear_drift
+# asserts via the preserved mean.
+BASE_ANGLE_DEG = 10.0
+
+# Injected drift slope (deg/frame) for the pure-ramp tests.  Magnitude
+# chosen from the apply_linear_detrend docstring ("hip angle sliding by
+# 10-30 deg from the first to the last cycle"): 0.2 deg/frame over a
+# 100-frame recording is a 20 deg drift, mid-range of that document.
+DEFAULT_DRIFT = 0.2
+
+
+def _make_angle_data(n_frames=100, drift_deg_per_frame=DEFAULT_DRIFT,
+                     amp=0.0, period=25, joints=None):
+    """Build a pivot dict with a linear drift and optional sinusoid."""
+    if joints is None:
+        joints = ["hip_L", "hip_R", "knee_L", "knee_R",
+                  "ankle_L", "ankle_R", "trunk_angle"]
+    frames = []
+    for i in range(n_frames):
+        osc = amp * np.sin(2 * np.pi * i / period) if amp else 0.0
+        drift = drift_deg_per_frame * i
+        frame = {"frame_idx": i}
+        for key in joints:
+            frame[key] = float(BASE_ANGLE_DEG + drift + osc)
+        frames.append(frame)
+    return {"angles": {"frames": frames}}
+
+
+def _slope_of(values):
+    """Least-squares slope of a series (NaN-safe)."""
+    vals = np.asarray(values, dtype=float)
+    mask = ~np.isnan(vals)
+    idx = np.arange(len(vals))
+    slope, _ = np.polyfit(idx[mask], vals[mask], 1)
+    return float(slope)
+
+
+def _series(data, key):
+    return [f.get(key) for f in data["angles"]["frames"]]
+
+
+def _per_cycle_ptp(values, period=25):
+    """Median peak-to-peak amplitude computed within each cycle."""
+    vals = np.asarray(values, dtype=float)
+    n_cycles = len(vals) // period
+    ptps = []
+    for c in range(n_cycles):
+        seg = vals[c * period:(c + 1) * period]
+        if not np.isnan(seg).any():
+            ptps.append(float(np.ptp(seg)))
+    return float(np.median(ptps)) if ptps else float("nan")
+
+
+# ── Detrend behaviour ────────────────────────────────────────────────
+
+
+def test_removes_linear_drift_preserves_mean():
+    data = _make_angle_data()  # pure ramp
+    before = _series(data, "hip_L")
+    assert abs(_slope_of(before) - DEFAULT_DRIFT) < 1e-9  # drift present
+    before_mean = float(np.mean(before))
+
+    apply_linear_detrend(data)
+
+    after = _series(data, "hip_L")
+    assert abs(_slope_of(after)) < 1e-9  # drift gone
+    assert abs(float(np.mean(after)) - before_mean) < 1e-9  # mean kept
+
+
+def test_preserves_per_cycle_rom():
+    """The documented contract is per-cycle ROM, not global peak-to-peak.
+
+    A slow drift contaminates windowed ROM measurements (the ramp tilts
+    each gait-cycle window); detrending must restore the oscillation
+    amplitude within every cycle.
+
+    Math note: OLS detrend subtracts its own fitted line, so the
+    residual slope is ~0 by construction (the OLS residual is
+    orthogonal to the regressors).  On a ramp+sinusoid composite the
+    fitted slope still carries the ramp/sinusoid cross-term bias, which
+    modulates the oscillation slightly; the remaining ROM deficit is
+    exactly that projection (here ~0.19 deg on a 10 deg ROM), and the
+    element-wise pin below reproduces the documented algorithm
+    (OLS fit, subtract trend, re-add mean) from first principles
+    instead of hardcoding magic numbers.
+    """
+    period = 20
+    drift, amp = 0.1, 5.0
+    data = _make_angle_data(drift_deg_per_frame=drift, amp=amp, period=period)
+    before = np.asarray(_series(data, "hip_L"))
+    before_ptp = _per_cycle_ptp(before, period)
+    true_ptp = 2.0 * amp
+    assert before_ptp < true_ptp  # drift contaminates windowed ROM
+
+    apply_linear_detrend(data)
+
+    after = np.asarray(_series(data, "hip_L"))
+
+    # Anatomical mean preserved (documented contract)
+    assert float(np.mean(after)) == pytest.approx(
+        float(np.mean(before)), abs=1e-9)
+    # Residual slope ~0: detrend subtracts its own OLS fit
+    assert abs(_slope_of(after)) < 1e-9
+
+    # Element-wise pin against the algorithm reproduced independently
+    idx = np.arange(len(before))
+    slope_hat, intercept_hat = np.polyfit(idx, before, 1)
+    expected = (before - (slope_hat * idx + intercept_hat)
+                + float(np.mean(before)))
+    assert after == pytest.approx(expected, abs=1e-9)
+
+    # Clinical meaning: ROM restored up to the cross-term distortion
+    after_ptp = _per_cycle_ptp(after, period)
+    assert after_ptp == pytest.approx(
+        _per_cycle_ptp(expected, period), abs=1e-9)
+    assert after_ptp > before_ptp
+    assert after_ptp == pytest.approx(true_ptp, abs=0.2)
+
+
+def test_sets_marker_and_is_idempotent():
+    data = _make_angle_data()
+    apply_linear_detrend(data)
+    assert data["angles"]["linear_detrended"] is True
+
+    snapshot = [dict(f) for f in data["angles"]["frames"]]
+    apply_linear_detrend(data)  # second call must be a no-op
+    assert data["angles"]["frames"] == snapshot
+
+
+def test_short_series_untouched():
+    """Joints below the internal minimum-sample guard are left unchanged.
+
+    The guard requires >= 20 valid samples (corrections.py). Series
+    clearly under any such bound must pass through bit-identical.
+    """
+    for n_frames in (0, 1, 5, 10, 19):
+        data = _make_angle_data(n_frames=n_frames)
+        before = _series(data, "knee_R")
+        apply_linear_detrend(data)
+        assert _series(data, "knee_R") == before, f"n={n_frames} modified"
+    # Boundary (exactly 20 valid samples) and above ARE detrended
+    for n_frames in (20, 25):
+        data = _make_angle_data(n_frames=n_frames)
+        apply_linear_detrend(data)
+        assert abs(_slope_of(_series(data, "knee_R"))) < 1e-9, (
+            f"n={n_frames} not detrended")
+
+
+def test_nan_values_skipped():
+    """NaN angle samples are preserved, valid neighbours are detrended."""
+    data = _make_angle_data(n_frames=50)
+    data["angles"]["frames"][7]["ankle_L"] = float("nan")
+    apply_linear_detrend(data)
+    assert np.isnan(data["angles"]["frames"][7]["ankle_L"])
+    valid = [f["ankle_L"] for f in data["angles"]["frames"]
+             if not np.isnan(f["ankle_L"])]
+    assert abs(_slope_of(valid)) < 1e-9
+
+
+def test_none_values_skipped():
+    data = _make_angle_data(n_frames=50)
+    data["angles"]["frames"][5]["hip_L"] = None
+    data["angles"]["frames"][6]["hip_L"] = None
+    apply_linear_detrend(data)
+    assert data["angles"]["frames"][5]["hip_L"] is None
+    assert data["angles"]["frames"][6]["hip_L"] is None
+    # Valid frames are detrended anyway
+    valid = [f["hip_L"] for f in data["angles"]["frames"]
+             if f["hip_L"] is not None]
+    assert abs(_slope_of(valid)) < 1e-9
+
+
+def test_other_frame_keys_preserved():
+    """Detrending touches only the target joints, never other keys."""
+    data = _make_angle_data(n_frames=40)
+    for f in data["angles"]["frames"]:
+        f["landmark_positions"] = {"LEFT_HIP": [0.5, 0.5]}
+    apply_linear_detrend(data)
+    for f in data["angles"]["frames"]:
+        assert f["landmark_positions"] == {"LEFT_HIP": [0.5, 0.5]}
+        assert "frame_idx" in f
+
+
+def test_custom_joints_only():
+    data = _make_angle_data()  # pure ramp on all joints
+    apply_linear_detrend(data, joints=["knee_L"])
+    assert abs(_slope_of(_series(data, "knee_L"))) < 1e-9
+    # Unlisted joints keep their drift
+    assert abs(_slope_of(_series(data, "hip_L")) - DEFAULT_DRIFT) < 1e-9
+
+
+def test_empty_angles_is_noop():
+    data = {"angles": {"frames": []}}
+    apply_linear_detrend(data)
+    assert data["angles"].get("linear_detrended") is not True
+
+    data_no_angles = {}
+    result = apply_linear_detrend(data_no_angles)
+    assert result is data_no_angles


### PR DESCRIPTION
# PR4 — feat(cli): opt-in sagittal drift correction (--detrend)

## What

Adds an **opt-in** `--detrend` flag to `myogait analyze`, wiring the
existing (fully unit-tested, previously unreferenced)
`apply_linear_detrend()` from `myogait.corrections` into the CLI, plus
documentation.

Long fixed-camera recordings show a slow angular drift (projection
artifact as subject-to-camera distance changes): hip angles can slide
10–30° across a recording. `apply_linear_detrend()` removes that linear
drift per joint while preserving the anatomical mean and per-cycle ROM.

## Why opt-in (important)

The correction family in `myogait/corrections.py` was calibrated on
healthy adults; on pathological gait a real kinematic drift can be part
of the clinical picture. The flag therefore **defaults OFF** — zero
behaviour change for every existing user. The help text, README and
tutorial all state the caveat explicitly.

## Changes

- `cli.py`: `--detrend` (store_true) on the `analyze` subparser; when set,
  detrend runs right after load/angles-check and before event detection,
  and the corrected JSON is persisted back (so downstream steps and later
  runs see the corrected angles). `getattr(args, "detrend", False)` keeps
  older Namespace objects safe.
- `README.md`: "Sagittal drift correction (opt-in)" subsection with usage
  (API + CLI) and clinical caveat.
- `docs/tutorial.md`: brief pointer to the subsection.

## Tests (TDD, RED demonstrated before GREEN)

- Flag registered on the analyze parser, default False.
- `--detrend` removes an injected linear ramp, persists the corrected JSON
  to disk (slope ~0, mean preserved to 1e-9), sets `linear_detrended`.
- Without the flag, angles on disk are untouched (no `linear_detrended`).

## Real-data evidence (integration test, not part of this diff)

Ran the pipeline on 14 real fixed-camera walking videos (Toronto Older
Adults Gait Archive, CC0, rear view): measured drift up to 0.176 deg/s
(~12° over 70 s, consistent with the documented 10–30°); after
`apply_linear_detrend` residual drift 0.0075 deg/s with per-cycle ROM
preserved at ~100 %. Caveat: rear view validates drift mechanics, not
sagittal-angle validity — that remains to be confirmed on lateral-view
data (see the institute's validation protocol draft).

## Verification (full local CI replay)

- `ruff check myogait/ tests/ --select E,W,F --ignore E501` → All checks passed
- `pytest tests/ --cov=myogait --cov-fail-under=75` → 1276 passed, coverage 77.81 %
- Functional check: `myogait analyze --help` shows the flag with its caveat.

## Note

Based on the CI-lint fix PR so the gate is green; happy to rebase once it lands.
